### PR TITLE
Fix build errors regarding missing android/key.properties file

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,38 +52,6 @@ Happy learning. :+1:
 
 ## Building the project
 
-### Missing Key.Properties file
-
-If you try to build the project straight away, you'll get an error complaining that a `key.properties` file is missing and Exit code 1 from: /Flutter-UI-Kit-master/android/gradlew app:properties:. To resolve that,
-
-1.  Open r\Flutter-UI-Kit-master\android\app\build.gradle file and comment following lines-
-
-```
-//keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
-
-signingConfigs {
-// release {
-// keyAlias keystoreProperties['keyAlias']
-// keyPassword keystoreProperties['keyPassword']
-// storeFile file(keystoreProperties['storeFile'])
-// storePassword keystoreProperties['storePassword']
-// }
-}
-buildTypes {
-// release {
-// signingConfig signingConfigs.release
-// }
-}
-```
-
-2.  Open r\Flutter-UI-Kit-master\android\local.properties and add -
-
-```
-flutter.versionName=1.0.0
-flutter.versionCode=1
-flutter.buildMode=release
-```
-
 ### The stack & building from source
 
 The project is currently built using the latest Flutter Master, with Dart 2 enabled.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -24,9 +24,11 @@ if (flutterVersionName == null) {
 apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
-def keystorePropertiesFile = rootProject.file("key.properties")
 def keystoreProperties = new Properties()
-keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+def keystorePropertiesFile = rootProject.file('key.properties')
+if (keystorePropertiesFile.exists()) {
+    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+}
 
 android {
     compileSdkVersion 27
@@ -49,7 +51,7 @@ android {
         release {
             keyAlias keystoreProperties['keyAlias']
             keyPassword keystoreProperties['keyPassword']
-            storeFile file(keystoreProperties['storeFile'])
+            storeFile keystoreProperties.containsKey('storeFile') ? file(keystoreProperties['storeFile']) : null
             storePassword keystoreProperties['storePassword']
         }
     }


### PR DESCRIPTION
This PR fixes `flutter run` and `flutter build apk --debug` in a fresh checkout of the app, without any need to first manually edit `android/app/build.gradle`.

See https://github.com/flutter/website/pull/1536 for more particulars.
