### PR TITLE
fix: http package missing in pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.2  
   font_awesome_flutter:
+  http:
   rxdart:
   flutter_masked_text:
   flutter_localizations:


### PR DESCRIPTION
fix https://github.com/iampawan/Flutter-UI-Kit/issues/21 with minimum changes.

note: run 'pod install' in /ios directory to build project for ios!