### PR TITLE
Fix 21 - Add missing HTTP dependency 

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,6 +27,7 @@ dev_dependencies:
   random_pk:
   flutter_test:
     sdk: flutter
+  http: ^0.12.0+1
 
 
 # For information on the generic Dart part of this file, see the


### PR DESCRIPTION
Just noticed that such deps was missing so decided to add. Fix #21 